### PR TITLE
Compatibility fix for scikit-learn 0.23.1

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -20,7 +20,7 @@ import gzip
 import posixpath
 import subprocess
 import warnings
-from sklearn.externals import six
+import six
 
 
 # Try Python 2 first, otherwise load from Python 3

--- a/polylearn/base.py
+++ b/polylearn/base.py
@@ -7,7 +7,7 @@ from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.utils.validation import check_X_y
 from sklearn.utils.multiclass import type_of_target
-from sklearn.externals import six
+import six
 
 from .loss import CLASSIFICATION_LOSSES, REGRESSION_LOSSES
 

--- a/polylearn/factorization_machine.py
+++ b/polylearn/factorization_machine.py
@@ -11,7 +11,7 @@ from sklearn.preprocessing import add_dummy_feature
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_array
 from sklearn.utils.extmath import safe_sparse_dot, row_norms
-from sklearn.externals import six
+import six
 
 try:
     from sklearn.exceptions import NotFittedError

--- a/polylearn/polynomial_network.py
+++ b/polylearn/polynomial_network.py
@@ -12,7 +12,7 @@ import numpy as np
 from sklearn.preprocessing import add_dummy_feature
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_array
-from sklearn.externals import six
+import six
 
 try:
     from sklearn.exceptions import NotFittedError

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,10 @@ if __name__ == '__main__':
           name=DISTNAME,
           maintainer=MAINTAINER,
           include_package_data=True,
+          install_requires=[
+              'six',
+              'scikit-learn'
+          ],
           maintainer_email=MAINTAINER_EMAIL,
           description=DESCRIPTION,
           license=LICENSE,


### PR DESCRIPTION
Removed 'six' from the dependency list and included it as an independent package.